### PR TITLE
Adds the widget listbox as an example of the use of aria-labelledby attribute showing that it makes elements apart in the markup related.

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,13 +288,13 @@
 					<section>
 						<h6>aria-label and aria-labelledby</h6>
 						<pre><code data-trim>
-							<body>
-								<div role="main" aria-labelledby="mainlabel">
-									<h1 id="mainlabel">Content Title</h1>
-								</div>
-
-								<button aria-label="Submit your answers">Submit</button>
-							</body>
+							<h2 id="label_fruit"> Available Fruit </h2>
+							<ul role="listbox" aria-labelledby="label_fruit">
+								<li role="option"> apples </li>
+								<li role="option"> bananas </li>
+								<li role="option"> cantaloupes </li>
+								<li role="option"> dates </li>
+							</ul>
 						</code></pre>
 						Gives screen readers more information about elements on the page.
 					</section>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_listbox_role